### PR TITLE
chore(sql): update module deps to v16

### DIFF
--- a/modules/mysql/mysql.tf
+++ b/modules/mysql/mysql.tf
@@ -8,7 +8,7 @@ resource "random_shuffle" "zone" {
 module "mysql-db" {
   #checkov:skip=CKV_TF_1:Ensure Terraform module sources use a commit hash
   source  = "GoogleCloudPlatform/sql-db/google//modules/mysql"
-  version = "14.1.0"
+  version = "16.1.0"
 
   name                 = var.name # Mandatory
   random_instance_name = true
@@ -21,6 +21,7 @@ module "mysql-db" {
   zone        = local.zone
   region      = var.region
   tier        = var.tier
+  edition     = var.edition
   user_labels = var.labels
 
   db_charset   = var.db_charset

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -39,6 +39,12 @@ variable "tier" {
   default     = "db-f1-micro"
 }
 
+variable "edition" {
+  description = "The database edition (ENTERPRISE, ENTERPRISE_PLUS)."
+  type        = string
+  default     = "ENTERPRISE"
+}
+
 variable "disk_limit" {
   description = "The maximum size to which storage can be auto increased."
   type        = number

--- a/modules/postgresql/postgresql.tf
+++ b/modules/postgresql/postgresql.tf
@@ -10,7 +10,7 @@ module "postgresql-db" {
   # Skipped because it doesn't need to be an option in the module below.
   #checkov:skip=CKV_TF_1:Ensure Terraform module sources use a commit hash
   source  = "GoogleCloudPlatform/sql-db/google//modules/postgresql"
-  version = "14.1.0"
+  version = "16.1.0"
 
   name                 = var.name # Mandatory
   random_instance_name = true
@@ -21,6 +21,7 @@ module "postgresql-db" {
   zone             = local.zone
   region           = var.region
   tier             = var.tier
+  edition          = var.edition
   user_labels      = var.labels
 
   db_charset   = var.db_charset

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -45,6 +45,11 @@ variable "tier" {
   default     = "db-f1-micro"
 }
 
+variable "edition" {
+  description = "The database edition (ENTERPRISE, ENTERPRISE_PLUS)."
+  type        = string
+  default     = "ENTERPRISE"
+}
 
 variable "disk_limit" {
   description = "The maximum size to which storage can be auto increased."


### PR DESCRIPTION
v14 modules do not support Cloud SQL editions and set ENTERPRISE_PLUS as default.
Added the variable and bumped to v16 to be able to choose